### PR TITLE
Move ahead

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_and_deploy:
-      uses: sensirion/.github/.github/workflows/driver.python.pypi_publish.yml@main
+      uses: sensirion/.github/.github/workflows/python_package.pypi_publish.yml@main
       secrets:
         PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 ---------
 
+1.0.2
+:::::
+- Fix CI
+- Fix links in README.md
+
 1.0.1
 :::::
 - Update project structure

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 This repository contains the common I2C driver used by various Sensirion
 sensor drivers. For details, please read the package description in
-[README.rst](README.rst).
+[README.rst](https://github.com/Sensirion/python-i2c-driver/blob/master/README.rst).
 
 
 ## Usage
 
-See package description in [README.rst](README.rst) and user manual at
+See package description in [README.rst](https://github.com/Sensirion/python-i2c-driver/blob/master/README.rst) and user manual at
 https://sensirion.github.io/python-i2c-driver/.
 
 ## Development
@@ -57,4 +57,4 @@ sphinx-versioning build docs docs/_build/html  # Build documentation
 
 ## License
 
-See [LICENSE](LICENSE).
+See [LICENSE](https://github.com/Sensirion/python-i2c-driver/blob/master/LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "sensirion-i2c-driver"
 description = "Base Driver for Communicating With I2C Devices"
 
 readme = "README.md"
-version =  "1.0.1"
+version =  "1.0.2"
 requires-python = ">=3.8,<4.0"
 
 authors = [


### PR DESCRIPTION
The links in the readme are not working when they are clicked on pypi. Futhermore the publish action proceeded only up to the point when the package was published to pypi.
Both are fixed with this PR and we may consider to make a release 1.0.2 afterwards 